### PR TITLE
Add support for installing plugins during the packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 ### 1. releasing / packaging along with integratin tests running:
 
 #### Options:
-- `--version`: opensearch version, default: `2.1.0`
+- `--version`: opensearch version, default: `2.2.0`
 - `--platform`: target platform, default: `linux`
+- `--plugins`: plugins to install in the tarball, default: `security asynchronous-search cross-cluster-replication`
 
 #### Run:
 1. `cd release`
@@ -13,5 +14,11 @@
 
    # or
     
-   bash run.sh --version 2.1.0 --platform linux
+   bash run.sh --version 2.2.0 --platform linux
+   
+   # or to set plugins and their tag versions (default to 0 if not set)
+   bash run.sh \
+       --version 2.2.0 \
+       --platform linux \
+       --plugins "security asynchronous-search:2 cross-cluster-replication:0"
    ```

--- a/release/docker/packaging-full/Dockerfile
+++ b/release/docker/packaging-full/Dockerfile
@@ -9,9 +9,17 @@ RUN \
     apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y \
+        apache2 \
         apt-transport-https \
         git \
         openjdk-11-jdk-headless
+
+COPY install_http_server.sh /
+
+RUN \
+    chmod +x /install_http_server.sh \
+    && . /install_http_server.sh \
+    && echo y | keytool -importcert -trustcacerts -cacerts -file /etc/ssl/certs/apache-selfsigned.crt -alias apache2 -storepass changeit
 
 
 WORKDIR /opensearch/dist/${VERSION}-${PLATFORM}
@@ -22,16 +30,26 @@ ENV PLATFORM=${PLATFORM}
 ENV DIST_DIR="/opensearch/dist/${VERSION}-${PLATFORM}"
 ENV PLUGINS_DIR="/opensearch/plugins/dist"
 ENV RELEASE_DIR="/opensearch/release"
+
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
+ENV OPENSEARCH_JAVA_OPTS="-Djavax.net.ssl.trustStore=${JAVA_HOME}/lib/security/cacerts"
+
 CMD \
-    ls -la \
+    cp "${PLUGINS_DIR}"/*.zip /var/www/localhost/ \
+    && service apache2 restart \
+    && service apache2 status \
+
     && tar -xzvf "${DIST_DIR}/opensearch-min-${VERSION}-${PLATFORM}.tar.gz" \
     && pushd "opensearch-${VERSION}" \
+
     && ( \
         for plugin in "${PLUGINS_DIR}"/*.zip; do \
-            echo "Installing Plugin: ${plugin}" \
-            && (echo y | bin/opensearch-plugin install "${plugin}") \
+            fname=$(basename "${plugin}") \
+            name=$(echo "${fname}" | sed -e "s/-${VERSION}.zip//") \
+            && echo "Installing Plugin: ${fname}" \
+            && (echo y | bin/opensearch-plugin remove "${name}") || true \
+            && (echo y | bin/opensearch-plugin install "https://localhost/${fname}")  \
         done \
     ) \
     && popd \
     && tar -czvf opensearch-${VERSION}-${PLATFORM}.tar.gz "opensearch-${VERSION}"
-

--- a/release/docker/packaging-full/Dockerfile
+++ b/release/docker/packaging-full/Dockerfile
@@ -1,0 +1,37 @@
+FROM ubuntu:22.04
+
+SHELL ["/bin/bash", "-c"]
+
+ARG VERSION=2.2.0
+ARG PLATFORM=linux
+
+RUN \
+    apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y \
+        apt-transport-https \
+        git \
+        openjdk-11-jdk-headless
+
+
+WORKDIR /opensearch/dist/${VERSION}-${PLATFORM}
+
+
+ENV VERSION=${VERSION}
+ENV PLATFORM=${PLATFORM}
+ENV DIST_DIR="/opensearch/dist/${VERSION}-${PLATFORM}"
+ENV PLUGINS_DIR="/opensearch/plugins/dist"
+ENV RELEASE_DIR="/opensearch/release"
+CMD \
+    ls -la \
+    && tar -xzvf "${DIST_DIR}/opensearch-min-${VERSION}-${PLATFORM}.tar.gz" \
+    && pushd "opensearch-${VERSION}" \
+    && ( \
+        for plugin in "${PLUGINS_DIR}"/*.zip; do \
+            echo "Installing Plugin: ${plugin}" \
+            && (echo y | bin/opensearch-plugin install "${plugin}") \
+        done \
+    ) \
+    && popd \
+    && tar -czvf opensearch-${VERSION}-${PLATFORM}.tar.gz "opensearch-${VERSION}"
+

--- a/release/docker/packaging-full/install_http_server.sh
+++ b/release/docker/packaging-full/install_http_server.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -e -x
+
+# enable ssl mode
+a2enmod ssl
+service apache2 restart
+
+# create ssl certificate
+openssl req \
+    -x509 \
+    -nodes \
+    -days 365 \
+    -newkey rsa:2048 \
+    -keyout /etc/ssl/private/apache-selfsigned.key \
+    -out /etc/ssl/certs/apache-selfsigned.crt \
+    -subj "/C=DE/ST=Berlin/L=Berlin/O=Canonical/CN=localhost"
+
+# Create site folder
+mkdir -p /var/www/localhost/
+chmod -R +r /var/www/localhost/
+
+# Update the apache config to pick up the cert and key
+mkdir -p /etc/apache2/sites-available/
+cat <<EOF > /etc/apache2/sites-available/localhost.conf
+<VirtualHost *:443>
+   ServerName localhost
+   DocumentRoot /var/www/localhost
+
+   SSLEngine on
+   SSLCertificateFile /etc/ssl/certs/apache-selfsigned.crt
+   SSLCertificateKeyFile /etc/ssl/private/apache-selfsigned.key
+</VirtualHost>
+EOF
+
+echo "printing site localhost"
+cat /etc/apache2/sites-available/localhost.conf
+
+# enable the configuration file
+a2ensite localhost.conf
+apache2ctl configtest
+service apache2 reload
+service apache2 stop

--- a/release/docker/packaging-plugins/Dockerfile
+++ b/release/docker/packaging-plugins/Dockerfile
@@ -1,0 +1,47 @@
+FROM ubuntu:22.04
+
+SHELL ["/bin/bash", "-c"]
+
+ARG VERSION="2.2.0"
+ARG PLUGINS="security"
+
+RUN \
+    apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y \
+        apt-transport-https \
+        git \
+        jq \
+        openjdk-11-jdk-headless
+
+WORKDIR /opensearch/plugins
+
+COPY plugins.json /tmp/plugins.json
+
+ENV VERSION=${VERSION}
+ENV PLUGINS=${PLUGINS}
+ENV BASE_PLUGINS_DIR="/opensearch/plugins"
+CMD \
+    git config --global advice.detachedHead false \
+    && readarray -td, plugins <<<"${PLUGINS}" \
+    && declare -p plugins \
+    && { \
+        for plugin in ${plugins}; do \
+            echo "Building plugin: opensearch-${plugin}" \
+
+            && read repo buildCmd < <(echo $(jq -r ".[\"${plugin}\"].repo, .[\"${plugin}\"].buildCmd" /tmp/plugins.json)) \
+            && rm -rf "${BASE_PLUGINS_DIR}/sources/${plugin}" \
+            && git clone -b "${VERSION}.0" --single-branch "${repo}" "${BASE_PLUGINS_DIR}/sources/${plugin}" \
+
+            && pushd "${BASE_PLUGINS_DIR}/sources/${plugin}/" \
+
+            && echo "Running: ${buildCmd/VERSION/$VERSION}" \
+            && eval "${buildCmd/VERSION/$VERSION}" \
+
+            && mkdir -p "${BASE_PLUGINS_DIR}/dist/" \
+            && mv build/distributions/opensearch-${plugin}-${VERSION}.0.zip "${BASE_PLUGINS_DIR}/dist/opensearch-${plugin}-${VERSION}.zip" \
+
+            && popd; \
+        done \
+    }
+

--- a/release/docker/packaging-plugins/Dockerfile
+++ b/release/docker/packaging-plugins/Dockerfile
@@ -29,17 +29,20 @@ CMD \
         for plugin in ${plugins}; do \
             echo "Building plugin: opensearch-${plugin}" \
 
-            && read repo buildCmd < <(echo $(jq -r ".[\"${plugin}\"].repo, .[\"${plugin}\"].buildCmd" /tmp/plugins.json)) \
-            && rm -rf "${BASE_PLUGINS_DIR}/sources/${plugin}" \
-            && git clone -b "${VERSION}.0" --single-branch "${repo}" "${BASE_PLUGINS_DIR}/sources/${plugin}" \
+            && PLUGIN_NAME=$(awk -F: '{print $1}' <<< "${plugin}") \
+            && TAG_VERSION=$(awk -F: '{print $2==""?"0":$2}' <<< "${plugin}") \
 
-            && pushd "${BASE_PLUGINS_DIR}/sources/${plugin}/" \
+            && read repo buildCmd < <(echo $(jq -r ".[\"${PLUGIN_NAME}\"].repo, .[\"${PLUGIN_NAME}\"].buildCmd" /tmp/plugins.json)) \
+            && rm -rf "${BASE_PLUGINS_DIR}/sources/${PLUGIN_NAME}" \
+            && git clone -b "${VERSION}.${TAG_VERSION}" --single-branch "${repo}" "${BASE_PLUGINS_DIR}/sources/${PLUGIN_NAME}" \
+
+            && pushd "${BASE_PLUGINS_DIR}/sources/${PLUGIN_NAME}/" \
 
             && echo "Running: ${buildCmd/VERSION/$VERSION}" \
             && eval "${buildCmd/VERSION/$VERSION}" \
 
             && mkdir -p "${BASE_PLUGINS_DIR}/dist/" \
-            && mv build/distributions/opensearch-${plugin}-${VERSION}.0.zip "${BASE_PLUGINS_DIR}/dist/opensearch-${plugin}-${VERSION}.zip" \
+            && mv build/distributions/opensearch-${PLUGIN_NAME}-${VERSION}.${TAG_VERSION}.zip "${BASE_PLUGINS_DIR}/dist/opensearch-${PLUGIN_NAME}-${VERSION}.zip" \
 
             && popd; \
         done \

--- a/release/docker/packaging-plugins/plugins.json
+++ b/release/docker/packaging-plugins/plugins.json
@@ -1,0 +1,18 @@
+{
+  "security": {
+    "repo": "https://github.com/opensearch-project/security",
+    "buildCmd": "./gradlew clean assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=VERSION -Dbuild.snapshot=false"
+  },
+  "asynchronous-search": {
+    "repo": "https://github.com/opensearch-project/asynchronous-search",
+    "buildCmd": "./gradlew clean assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=VERSION -Dbuild.snapshot=false"
+  },
+  "cross-cluster-replication": {
+    "repo": "https://github.com/opensearch-project/cross-cluster-replication",
+    "buildCmd": "./gradlew clean assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=VERSION -Dbuild.snapshot=false"
+  },
+  "ml": {
+    "repo": "https://github.com/opensearch-project/ml-commons",
+    "buildCmd": "./gradlew clean assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=VERSION -Dbuild.snapshot=false"
+  }
+}

--- a/release/docker/packaging/Dockerfile
+++ b/release/docker/packaging/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-ARG VERSION=2.1.0
+ARG VERSION=2.2.0
 ARG PLATFORM=linux
 
 RUN \

--- a/release/docker/testing-plugins/Dockerfile
+++ b/release/docker/testing-plugins/Dockerfile
@@ -1,0 +1,41 @@
+FROM ubuntu:22.04
+
+ARG VERSION=2.2.0
+ARG PLUGINS=security
+
+RUN \
+    apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y \
+        apt-transport-https \
+        git \
+        jq \
+        openjdk-11-jdk-headless
+
+
+WORKDIR /opensearch/plugins
+
+COPY plugins.json /tmp/plugins.json
+
+ENV PLUGINS=${PLUGINS}
+ENV BASE_PLUGINS_DIR="/opensearch/plugins"
+CMD \
+    readarray -td, plugins <<<"${PLUGINS}" \
+    && declare -p plugins \
+    && { \
+        for plugin in ${plugins}; do \
+            echo "Testing plugin: opensearch-${plugin}" \
+
+            && read integTestsCmd < <(echo $(jq -r ".[\"${plugin}\"].integrationTestsCmd" /tmp/plugins.json)) \
+
+            && pushd "${BASE_PLUGINS_DIR}/sources/${plugin}/" \
+
+            && echo "Running: ${integTestsCmd}" \
+            && eval "${integTestsCmd}" \
+
+            && popd; \
+        done \
+    }
+
+
+

--- a/release/docker/testing-plugins/plugins.json
+++ b/release/docker/testing-plugins/plugins.json
@@ -1,0 +1,14 @@
+{
+  "security": {
+    "integrationTestsCmd": "OPENDISTRO_SECURITY_TEST_OPENSSL_OPT=true ./gradlew test"
+  },
+  "asynchronous-search": {
+    "integrationTestsCmd": "OPENSEARCH_HOME=/opensearch/source ./gradlew integTest -PnumNodes=3"
+  },
+  "cross-cluster-replication": {
+    "integrationTestsCmd": "OPENSEARCH_HOME=/opensearch/source ./gradlew integTest"
+  },
+  "ml": {
+    "integrationTestsCmd": "OPENSEARCH_HOME=/opensearch/source ./gradlew integTest -PnumNodes=3"
+  }
+}

--- a/release/docker/testing/Dockerfile
+++ b/release/docker/testing/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-ARG VERSION=2.1.0
+ARG VERSION=2.2.0
 ARG PLATFORM=linux
 
 RUN \
@@ -26,7 +26,7 @@ ENV PLATFORM=${PLATFORM}
 
 # create an opensearch user/group, opensearch cannot run with root
 CMD \
-    find /opensearch/dist/${VERSION}-${PLATFORM}/ -type f -name "*.tar.gz" \
+    find /opensearch/dist/${VERSION}-${PLATFORM}/ -type f -name "-min-*.tar.gz" \
         | xargs basename \
         | ( \
           read -r name \

--- a/release/run.sh
+++ b/release/run.sh
@@ -1,8 +1,27 @@
 #!/usr/bin/env bash
 
-set -e
+set -e -x
 
 # --------------------------------------------------------------------------------
+
+version=${version:-2.2.0}
+platform=${platform:-linux}
+plugins=${plugins:-"security asynchronous-search cross-cluster-replication"}
+
+
+function parse_args () {
+    while [ $# -gt 0 ]; do
+        if [[ $1 == "--help" ]]; then
+            usage
+            exit 0
+        elif [[ $1 == *"--"* ]]; then
+            param="${1/--/}"
+            declare "$param"="$2"
+        fi
+        shift
+    done
+}
+
 
 function build_image () {
     docker build \
@@ -14,6 +33,9 @@ function build_image () {
 }
 
 function run_container () {
+    docker stop "$1" || true
+    docker rm --force "$1" || true
+
     docker run \
         -d \
         -v opensearch:/opensearch \
@@ -38,75 +60,98 @@ function wait_until_container_exists () {
     printf "\t --- \n\t succeeded... \n"
 }
 
-# --------------------------------------------------------------------------------
 
+# --------------------------------------------------------------------------------
 pushd docker
 
-# --------------------------------------------------------------------------------
 # ------------------------- Command line args parsing ----------------------------
 printf "\n ------------- \n Command line parsing... \n ------------- \n"
 
-version=${version:-2.1.0}
-platform=${platform:-linux}
+parse_args "$@"
 
-while [ $# -gt 0 ]; do
-    if [[ $1 == "--help" ]]; then
-        usage
-        exit 0
-    elif [[ $1 == *"--"* ]]; then
-        param="${1/--/}"
-        declare "$param"="$2"
-    fi
-    shift
-done
-
-printf "\t Version: %s" "${version}"
-printf "\t Platform: %s" "${platform}"
-
-# --------------------------------------------------------------------------------
 # ------------- Create local volume where to store the tarballs ------------------
 printf "\n ------------- \n Creating local volumes... \n ------------- \n"
 
 docker volume create opensearch
 docker volume inspect opensearch
 
-# --------------------------------------------------------------------------------
-# ---------------------------------- Packaging -----------------------------------
-printf "\n ------------- \n Packaging... \n ------------- \n"
-
-pushd packaging
-
-# Build the Image for packaging a platform specific tarball
-IMAGE_NAME_PACKAGING=opensearch-packaging-"${version}"-"${platform}"
-build_image "${version}" "${platform}" "${IMAGE_NAME_PACKAGING}"
-
-# Store the platform-specific tarball in the local volume
-run_container "packaging" "${IMAGE_NAME_PACKAGING}"
-
-popd
-
-# --------------------------------------------------------------------------------
-
-wait_until_container_exists "packaging"
+# -------------------------- Packaging opensearch-min ---------------------------
+#printf "\n ------------- \n Packaging... \n ------------- \n"
+#
+#pushd packaging
+#
+## Build the Image for packaging a platform specific tarball
+#IMAGE_NAME_PACKAGING=opensearch-packaging-"${version}"-"${platform}"
+#build_image "${version}" "${platform}" "${IMAGE_NAME_PACKAGING}"
+#
+## Store the platform-specific tarball in the local volume
+#run_container "packaging" "${IMAGE_NAME_PACKAGING}"
+#
+#popd
+#
+## --------------------------------------------------------------------------------
+#
+#wait_until_container_exists "packaging"
 
 # --------------------------------------------------------------------------------
 # ---------------------------------- Testing -------------------------------------
-printf "\n ------------- \n Testing... \n ------------- \n"
+#printf "\n ------------- \n Testing... \n ------------- \n"
+#
+#pushd testing
+#
+## Build the Image for running integration tests against the generated platform-specific tarball
+#IMAGE_NAME_TESTING=opensearch-testing-"${version}"-"${platform}"
+#build_image "${version}" "${platform}" "${IMAGE_NAME_TESTING}"
+#
+## Run the integration tests and store a success file upon success
+#run_container "testing" "${IMAGE_NAME_TESTING}"
+#
+#popd
+#
+## --------------------------------------------------------------------------------
+#
+#wait_until_container_exists "testing"
 
-pushd testing
+# --------------------------------------------------------------------------------
+printf "\n ------------- \n Packaging Plugins... \n ------------- \n"
 
-# Build the Image for running integration tests against the generated platform-specific tarball
-IMAGE_NAME_TESTING=opensearch-testing-"${version}"-"${platform}"
-build_image "${version}" "${platform}" "${IMAGE_NAME_TESTING}"
+pushd packaging-plugins
 
-# Run the integration tests and store a success file upon success
-run_container "testing" "${IMAGE_NAME_TESTING}"
+# Build the Image for packaging a platform specific tarball
+IMAGE_NAME_PACKAGING_PLUGINS=opensearch-packaging-plugins-"${version}"
+docker build \
+        -t "${IMAGE_NAME_PACKAGING_PLUGINS}" \
+        --build-arg VERSION="${version}" \
+        --build-arg PLUGINS="${plugins}" \
+        --no-cache \
+        --progress=plain .
+# build_image "${version}" "${platform}" "${IMAGE_NAME_PACKAGING}"
+
+# Store the platform-specific tarball in the local volume
+run_container "packaging-plugins" "${IMAGE_NAME_PACKAGING_PLUGINS}"
 
 popd
 
+wait_until_container_exists "packaging-plugins"
+
 # --------------------------------------------------------------------------------
 
-wait_until_container_exists "testing"
+
+# --------------------------------------------------------------------------------
+printf "\n -------- \n Installing Plugins and Packaging full release... \n ------- \n"
+
+pushd packaging-full
+
+# Build the Image for packaging a platform specific tarball
+IMAGE_NAME_PACKAGING_FULL=opensearch-packaging-full-"${version}"-"${platform}"
+build_image "${version}" "${platform}" "${IMAGE_NAME_PACKAGING_FULL}"
+
+# Store the platform-specific tarball in the local volume
+run_container "packaging-full" "${IMAGE_NAME_PACKAGING_FULL}"
+
+popd
+
+wait_until_container_exists "packaging-full"
 
 # --------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR contains:
- bump of opensearch version to `2.2.0`
- description of "base" plugins in json files
- packaging of plugins as zip
- running of their integration tests
- installation of plugin on the opensearch min distribution
- packaging of opensearch with those plugins